### PR TITLE
Revert response parsing logic

### DIFF
--- a/scd4x.go
+++ b/scd4x.go
@@ -255,10 +255,12 @@ func (sensor SCD4x) readCommand(cmd Command) ([]Response, error) {
 	if err := sensor.dev.Tx(c, r); err != nil {
 		return nil, fmt.Errorf("error while %s: %v", cmd.desc, err)
 	}
-	resp := make([]Response, int(cmd.respBytes)-2)
+
+	resp := []Response{}
 	for i := 0; i < int(cmd.respBytes)-2; i += 3 {
 		j := Response{data: r[i : i+2], crc: r[i+2]}
-		resp[i] = j
+		resp = append(resp, j)
+
 	}
 	if cmd.delay > 0 {
 		time.Sleep(cmd.delay)


### PR DESCRIPTION
It looks like there was an unintended regression in https://github.com/aldernero/scd4x/commit/5c00e43e899a4f3f46aa58766ff48893da1d56b4 in the `readCommand` method, specifically in https://github.com/aldernero/scd4x/blob/main/scd4x.go#L258-L262. I reverted to prior logic, which works.

The problem:
The measure command doesn't work. It fails with a CRC check every time. The cause is that the command expects 3 3-byte responses, but `resp := make([]Response, int(cmd.respBytes)-2)` initializes a slice of 7 Responses. Only [0], [3], and [6] are populated. The other 4 Responses are empty and fail the CRC check.