### PR TITLE
Replace instances of 2^16 with 2^16-1

### DIFF
--- a/scd4x.go
+++ b/scd4x.go
@@ -255,10 +255,12 @@ func (sensor SCD4x) readCommand(cmd Command) ([]Response, error) {
 	if err := sensor.dev.Tx(c, r); err != nil {
 		return nil, fmt.Errorf("error while %s: %v", cmd.desc, err)
 	}
-	resp := make([]Response, int(cmd.respBytes)-2)
+
+	resp := []Response{}
 	for i := 0; i < int(cmd.respBytes)-2; i += 3 {
 		j := Response{data: r[i : i+2], crc: r[i+2]}
-		resp[i] = j
+		resp = append(resp, j)
+
 	}
 	if cmd.delay > 0 {
 		time.Sleep(cmd.delay)

--- a/scd4x.go
+++ b/scd4x.go
@@ -172,7 +172,7 @@ func (sensor SCD4x) GetTemperatureOffset() (float64, error) {
 	if !resp[0].CrcMatch() {
 		return 0, fmt.Errorf("temperature offset CRC mismatch")
 	}
-	return -45 + 175*float64(resp[0].GetData())/65535, nil
+	return -45 + 105*float64(resp[0].GetData())/65535, nil
 }
 
 func (sensor SCD4x) GetSensorAltitude() (uint16, error) {

--- a/scd4x.go
+++ b/scd4x.go
@@ -172,7 +172,7 @@ func (sensor SCD4x) GetTemperatureOffset() (float64, error) {
 	if !resp[0].CrcMatch() {
 		return 0, fmt.Errorf("temperature offset CRC mismatch")
 	}
-	return -45 + 105*float64(resp[0].GetData())/65535, nil
+	return -45 + 175*float64(resp[0].GetData())/65535, nil
 }
 
 func (sensor SCD4x) GetSensorAltitude() (uint16, error) {

--- a/scd4x.go
+++ b/scd4x.go
@@ -151,13 +151,9 @@ func (sensor SCD4x) ReadMeasurement() (SensorData, error) {
 			return result, fmt.Errorf("measurement CRC mismatch")
 		}
 	}
-	offset, err := sensor.GetTemperatureOffset()
-	if err != nil {
-		return result, err
-	}
 	result = SensorData{
 		CO2:  resp[0].GetData(),
-		Temp: (-45 + 175*float64(resp[1].GetData())/65535) + offset - 4,
+		Temp: -45 + 175*float64(resp[1].GetData())/65535,
 		Rh:   100 * float64(resp[2].GetData()) / 65535,
 	}
 	if sensor.UseFahrenheit {

--- a/scd4x.go
+++ b/scd4x.go
@@ -151,9 +151,13 @@ func (sensor SCD4x) ReadMeasurement() (SensorData, error) {
 			return result, fmt.Errorf("measurement CRC mismatch")
 		}
 	}
+	offset, err := sensor.GetTemperatureOffset()
+	if err != nil {
+		return result, err
+	}
 	result = SensorData{
 		CO2:  resp[0].GetData(),
-		Temp: -45 + 175*float64(resp[1].GetData())/65535,
+		Temp: (-45 + 175*float64(resp[1].GetData())/65535) + offset - 4,
 		Rh:   100 * float64(resp[2].GetData()) / 65535,
 	}
 	if sensor.UseFahrenheit {

--- a/scd4x.go
+++ b/scd4x.go
@@ -153,8 +153,8 @@ func (sensor SCD4x) ReadMeasurement() (SensorData, error) {
 	}
 	result = SensorData{
 		CO2:  resp[0].GetData(),
-		Temp: -45 + 175*float64(resp[1].GetData())/65536,
-		Rh:   100 * float64(resp[2].GetData()) / 65536,
+		Temp: -45 + 175*float64(resp[1].GetData())/65535,
+		Rh:   100 * float64(resp[2].GetData()) / 65535,
 	}
 	if sensor.UseFahrenheit {
 		result.Temp = celsius2Fahreheit(result.Temp)
@@ -172,7 +172,7 @@ func (sensor SCD4x) GetTemperatureOffset() (float64, error) {
 	if !resp[0].CrcMatch() {
 		return 0, fmt.Errorf("temperature offset CRC mismatch")
 	}
-	return -45 + 175*float64(resp[0].GetData())/65536, nil
+	return -45 + 175*float64(resp[0].GetData())/65535, nil
 }
 
 func (sensor SCD4x) GetSensorAltitude() (uint16, error) {


### PR DESCRIPTION
Per https://sensirion.com/media/documents/48C4B7FB/67FE0194/CD_DS_SCD4x_Datasheet_D1.pdf there are various places where a formula should contain 65535 (ie, 2^16 - 1) rather than 65536 (ie 2^16) which is what appears currently 